### PR TITLE
Fix possible memory leak and an uninitialized variable issue

### DIFF
--- a/NMSSH/NMSSHChannel.m
+++ b/NMSSH/NMSSHChannel.m
@@ -69,16 +69,16 @@
 
     [self setChannel:channel];
 
-    int rc = 0;
-
     // Try to set environment variables
     if (self.environmentVariables) {
         for (NSString *key in self.environmentVariables) {
             if ([key isKindOfClass:[NSString class]] && [[self.environmentVariables objectForKey:key] isKindOfClass:[NSString class]]) {
-                rc = libssh2_channel_setenv(self.channel, [key UTF8String], [[self.environmentVariables objectForKey:key] UTF8String]);
+                libssh2_channel_setenv(self.channel, [key UTF8String], [[self.environmentVariables objectForKey:key] UTF8String]);
             }
         }
     }
+
+    int rc = 0;
 
     // If requested, try to allocate a pty
     if (self.requestPty) {
@@ -326,7 +326,7 @@
                                            0, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0))];
     dispatch_source_set_event_handler(self.source, ^{
         NMSSHLogVerbose(@"Data available on the socket!");
-        ssize_t rc, erc;
+        ssize_t rc, erc=0;
         char buffer[self.bufferSize];
 
         while (self.channel != NULL &&

--- a/NMSSH/NMSSHSession.m
+++ b/NMSSH/NMSSHSession.m
@@ -5,7 +5,6 @@
 @property (nonatomic, assign) LIBSSH2_AGENT *agent;
 
 @property (nonatomic, assign, getter = rawSession) LIBSSH2_SESSION *session;
-@property (nonatomic, readwrite) CFSocketRef socket;
 @property (nonatomic, readwrite, getter = isConnected) BOOL connected;
 @property (nonatomic, strong) NSString *host;
 @property (nonatomic, strong) NSString *username;
@@ -176,15 +175,15 @@
     }
 
     // Try to create the socket
-    [self setSocket:CFSocketCreate(kCFAllocatorDefault, PF_INET, SOCK_STREAM, IPPROTO_IP, kCFSocketNoCallBack, NULL, NULL)];
-    if (!self.socket) {
+    _socket = CFSocketCreate(kCFAllocatorDefault, PF_INET, SOCK_STREAM, IPPROTO_IP, kCFSocketNoCallBack, NULL, NULL);
+    if (!_socket) {
         NMSSHLogError(@"Error creating the socket");
         return NO;
     }
 
     // Set NOSIGPIPE
     int set = 1;
-    if (setsockopt(CFSocketGetNative(self.socket), SOL_SOCKET, SO_NOSIGPIPE, (void *)&set, sizeof(set)) != 0) {
+    if (setsockopt(CFSocketGetNative(_socket), SOL_SOCKET, SO_NOSIGPIPE, (void *)&set, sizeof(set)) != 0) {
         NMSSHLogError(@"Error setting socket option");
         [self disconnect];
         return NO;
@@ -231,7 +230,7 @@
             continue;
         }
 
-        error = CFSocketConnectToAddress(self.socket, (__bridge CFDataRef)[NSData dataWithBytes:address length:address->ss_len], [timeout doubleValue]);
+        error = CFSocketConnectToAddress(_socket, (__bridge CFDataRef)[NSData dataWithBytes:address length:address->ss_len], [timeout doubleValue]);
 
         if (error) {
             NMSSHLogVerbose(@"Socket connection to %@ on port %ld failed with reason %li, trying next address...", ipAddress, (long)port, error);
@@ -263,7 +262,7 @@
     }
 
     // Start the session
-    if (libssh2_session_handshake(self.session, CFSocketGetNative(self.socket))) {
+    if (libssh2_session_handshake(self.session, CFSocketGetNative(_socket))) {
         NMSSHLogError(@"Failure establishing SSH session");
         [self disconnect];
 
@@ -317,10 +316,10 @@
         [self setSession:NULL];
     }
 
-    if (self.socket) {
-        CFSocketInvalidate(self.socket);
-        CFRelease(self.socket);
-        [self setSocket:NULL];
+    if (_socket) {
+        CFSocketInvalidate(_socket);
+        CFRelease(_socket);
+        _socket = NULL;
     }
 
     libssh2_exit();


### PR DESCRIPTION
I checked my project (which is using NMSSH via cocoapods) with the static analyzer from Xcode 5.1 and found several issues, which I fixed in this pull request:
- Apple recommends against accessing C pointers via properties, if you pass them to CoreFoundation C functions. (Could leak memory in some cases)I removed the readwrite property and used the instance variable directly in your CF calls. The readonly property from the header file can remain.
- The variable erc might be used uninitialized ("garbage value"), I set it to 0
- I moved one `int rc = 0;` declaration because the result was not used until some lines below

Now, the Xcode Analyzer is happy again :)

Best regards,
Clemens
