### PR TITLE
Access logger from Swift

### DIFF
--- a/NMSSH/Config/NMSSHLogger.h
+++ b/NMSSH/Config/NMSSHLogger.h
@@ -21,6 +21,11 @@ typedef NS_OPTIONS(NSUInteger, NMSSHLogLevel) {
  */
 + (NMSSHLogger *)logger;
 
+/**
+For Swift: so we can access it as a method(Swift does not allow static properties)
+*/
++(instancetype)sharedInstance;
+
 /// ----------------------------------------------------------------------------
 /// @name Logger settings
 /// ----------------------------------------------------------------------------

--- a/NMSSH/Config/NMSSHLogger.m
+++ b/NMSSH/Config/NMSSHLogger.m
@@ -39,6 +39,11 @@ typedef NS_OPTIONS(NSUInteger, NMSSHLogFlag) {
     return logger;
 }
 
++(instancetype)sharedInstance
+{
+    return NMSSHLogger.logger;
+}
+
 #if !(OS_OBJECT_USE_OBJC)
 - (void)dealloc {
     dispatch_release(self.loggerQueue);


### PR DESCRIPTION
This should allow you to access the logger settings from Swift by calling(in Swift):
NMSSHLogger.sharedinstance().a_property
