### PR TITLE
Make the logger accessible from Swift. Renamed it to sharedLogger.

### DIFF
--- a/NMSSH/Config/NMSSH+Protected.h
+++ b/NMSSH/Config/NMSSH+Protected.h
@@ -9,10 +9,10 @@
 
 #define kNMSSHBufferSize (0x4000)
 
-#define NMSSHLogVerbose(frmt, ...) [[NMSSHLogger logger] logVerbose:[NSString stringWithFormat:frmt, ##__VA_ARGS__]]
-#define NMSSHLogInfo(frmt, ...) [[NMSSHLogger logger] logInfo:[NSString stringWithFormat:frmt, ##__VA_ARGS__]]
-#define NMSSHLogWarn(frmt, ...) [[NMSSHLogger logger] logWarn:[NSString stringWithFormat:frmt, ##__VA_ARGS__]]
-#define NMSSHLogError(frmt, ...) [[NMSSHLogger logger] logError:[NSString stringWithFormat:frmt, ##__VA_ARGS__]]
+#define NMSSHLogVerbose(frmt, ...) [[NMSSHLogger sharedLogger] logVerbose:[NSString stringWithFormat:frmt, ##__VA_ARGS__]]
+#define NMSSHLogInfo(frmt, ...) [[NMSSHLogger sharedLogger] logInfo:[NSString stringWithFormat:frmt, ##__VA_ARGS__]]
+#define NMSSHLogWarn(frmt, ...) [[NMSSHLogger sharedLogger] logWarn:[NSString stringWithFormat:frmt, ##__VA_ARGS__]]
+#define NMSSHLogError(frmt, ...) [[NMSSHLogger sharedLogger] logError:[NSString stringWithFormat:frmt, ##__VA_ARGS__]]
 
 #define strlen (unsigned int)strlen
 

--- a/NMSSH/Config/NMSSHLogger.h
+++ b/NMSSH/Config/NMSSHLogger.h
@@ -16,10 +16,10 @@ typedef NS_OPTIONS(NSUInteger, NMSSHLogLevel) {
 
 /**
  Retrieve the shared logger instance
-
+ 
  @returns Shared logger
  */
-+ (NMSSHLogger *)logger;
++ (instancetype) sharedLogger;
 
 /// ----------------------------------------------------------------------------
 /// @name Logger settings

--- a/NMSSH/Config/NMSSHLogger.h
+++ b/NMSSH/Config/NMSSHLogger.h
@@ -21,11 +21,6 @@ typedef NS_OPTIONS(NSUInteger, NMSSHLogLevel) {
  */
 + (NMSSHLogger *)logger;
 
-/**
-For Swift: so we can access it as a method(Swift does not allow static properties)
-*/
-+(instancetype)sharedInstance;
-
 /// ----------------------------------------------------------------------------
 /// @name Logger settings
 /// ----------------------------------------------------------------------------

--- a/NMSSH/Config/NMSSHLogger.h
+++ b/NMSSH/Config/NMSSHLogger.h
@@ -21,6 +21,11 @@ typedef NS_OPTIONS(NSUInteger, NMSSHLogLevel) {
  */
 + (NMSSHLogger *)logger;
 
+/**
+For Swift: so we can access it as a method(Swift does not allow static properties)
+*/
++(instancetype)sharedInstance;
+
 /// ----------------------------------------------------------------------------
 /// @name Logger settings
 /// ----------------------------------------------------------------------------

--- a/NMSSH/Config/NMSSHLogger.m
+++ b/NMSSH/Config/NMSSHLogger.m
@@ -9,6 +9,12 @@ typedef NS_OPTIONS(NSUInteger, NMSSHLogFlag) {
 };
 
 @interface NMSSHLogger ()
+
+/**
+ The shared logger instance, now private
+ */
++ (NMSSHLogger *)logger;
+
 #if OS_OBJECT_USE_OBJC
 @property (nonatomic, strong) dispatch_queue_t loggerQueue;
 #else
@@ -37,6 +43,11 @@ typedef NS_OPTIONS(NSUInteger, NMSSHLogFlag) {
     });
 
     return logger;
+}
+
++ (instancetype) sharedLogger
+{
+    return NMSSHLogger.logger;
 }
 
 #if !(OS_OBJECT_USE_OBJC)

--- a/NMSSH/Config/NMSSHLogger.m
+++ b/NMSSH/Config/NMSSHLogger.m
@@ -39,6 +39,11 @@ typedef NS_OPTIONS(NSUInteger, NMSSHLogFlag) {
     return logger;
 }
 
++(instancetype)sharedInstance
+{
+    return NMSSHLogger.logger;
+}
+
 #if !(OS_OBJECT_USE_OBJC)
 - (void)dealloc {
     dispatch_release(self.loggerQueue);

--- a/NMSSH/Config/NMSSHLogger.m
+++ b/NMSSH/Config/NMSSHLogger.m
@@ -39,11 +39,6 @@ typedef NS_OPTIONS(NSUInteger, NMSSHLogFlag) {
     return logger;
 }
 
-+(instancetype)sharedInstance
-{
-    return NMSSHLogger.logger;
-}
-
 #if !(OS_OBJECT_USE_OBJC)
 - (void)dealloc {
     dispatch_release(self.loggerQueue);


### PR DESCRIPTION
Renamed the logger accessor to sharedLogger and made the actual property private.
Renamed in the project uses of logger to sharedLogger.