### PR TITLE
Fixed error when trying to close not opened channel

### DIFF
--- a/NMSSH/NMSSHChannel.m
+++ b/NMSSH/NMSSHChannel.m
@@ -105,7 +105,9 @@
 
 - (void)closeChannel {
     // Set blocking mode
-    libssh2_session_set_blocking(self.session.rawSession, 1);
+    if (self.session.rawSession) {
+        libssh2_session_set_blocking(self.session.rawSession, 1);
+    }
 
     if (self.channel) {
         int rc;


### PR DESCRIPTION
If connection fails it throws EXC_BAD_ACCESS