### PR TITLE
Fixes error when closing and reopening a shell.

### DIFF
--- a/NMSSH/NMSSHChannel.m
+++ b/NMSSH/NMSSHChannel.m
@@ -419,6 +419,7 @@
 #if !(OS_OBJECT_USE_OBJC)
         dispatch_release(self.source);
 #endif
+        [self setSource: nil];
     }
 
     if (self.type == NMSSHChannelTypeShell) {


### PR DESCRIPTION
When you close a shell and then later open a new shell later, the following throws an error:
if (self.source) {
  dispatch_release(self.source);
}