### PR TITLE
docs: fix simple typo, expessed -> expressed

### DIFF
--- a/NMSSHTests/Settings/lib/YAML.framework/Versions/A/Headers/yaml.h
+++ b/NMSSHTests/Settings/lib/YAML.framework/Versions/A/Headers/yaml.h
@@ -1718,7 +1718,7 @@ typedef struct yaml_emitter_s {
         size_t length;
         /** Does the scalar contain line breaks? */
         int multiline;
-        /** Can the scalar be expessed in the flow plain style? */
+        /** Can the scalar be expressed in the flow plain style? */
         int flow_plain_allowed;
         /** Can the scalar be expressed in the block plain style? */
         int block_plain_allowed;


### PR DESCRIPTION
There is a small typo in NMSSHTests/Settings/lib/YAML.framework/Versions/A/Headers/yaml.h.

Should read `expressed` rather than `expessed`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md