### PR TITLE
NMSSHChannel: fix potential resource leak

### DIFF
--- a/NMSSH/NMSSHChannel.m
+++ b/NMSSH/NMSSHChannel.m
@@ -567,6 +567,7 @@
             if (rc < 0) {
                 NMSSHLogError(@"Failed writing file");
                 [self closeChannel];
+                fclose(local);
                 return NO;
             }
             else {


### PR DESCRIPTION
Xcode 16.3’s analyze reported a potential resource leak. The opened file handle ‘local’ was not closed properly in a edge case.
@Frugghi If you are still there: please review and merge. I applied the patch in my own repo for a iOS app. Xcode 16.3’s analyze succeeded once again.

![nmssh-2025-04-26-153820](https://github.com/user-attachments/assets/36816ead-7b34-4571-8afd-d94f7ae25fe8)
